### PR TITLE
Prevents player from teleporting to lobby before death.

### DIFF
--- a/HungerGames/src/hungergames/EventListener.php
+++ b/HungerGames/src/hungergames/EventListener.php
@@ -99,7 +99,7 @@ class EventListener implements Listener{
         $p = $e->getPlayer();
         if($this->HGApi->getStorage()->isPlayerSet($p)){
             $game = $this->HGApi->getStorage()->getPlayerGame($p);
-            if($game !== null) $this->HGApi->getGlobalManager()->getGameManager($game)->removePlayer($p, true);
+            if($game !== null) $this->HGApi->getGlobalManager()->getGameManager($game)->removePlayerWithoutTeleport($p, true);
         }
         elseif($this->HGApi->getStorage()->isPlayerWaiting($p)){
             $game = $this->HGApi->getStorage()->getWaitingPlayerGame($p);

--- a/HungerGames/src/hungergames/lib/mgr/GameManager.php
+++ b/HungerGames/src/hungergames/lib/mgr/GameManager.php
@@ -187,6 +187,23 @@ class GameManager{
             $this->sendGameMessage(Msg::color(str_replace(["%player%", "%game%"], [$p->getName(), $this->getGame()->getName()], Msg::getHGMessage("hg.message.quit"))));
         }
     }
+    
+        /**
+     * Removes player from game without teleporting
+     *
+     * @param Player $p
+     * @param bool $message
+     */
+    public function removePlayerWithoutTeleport(Player $p, $message = false){
+        $this->HGApi->getStorage()->removePlayer($p);
+        foreach($this->HGApi->getScriptManager()->getScripts() as $script){
+            if(!$script->isEnabled()) continue;
+            $script->onPlayerQuitGame($p, $this->getGame());
+        }
+        if($message){
+            $this->sendGameMessage(Msg::color(str_replace(["%player%", "%game%"], [$p->getName(), $this->getGame()->getName()], Msg::getHGMessage("hg.message.quit"))));
+        }
+    }
     /**
      * Adds player into game
      *


### PR DESCRIPTION
Now player dies where they were killed and drop items into the arena, rather than dying in the lobby and dropping items there.

Fix for Issue #49 