### PR TITLE
Clearing Inventory

### DIFF
--- a/HungerGames/src/hungergames/EventListener.php
+++ b/HungerGames/src/hungergames/EventListener.php
@@ -10,6 +10,7 @@ use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerMoveEvent;
 use pocketmine\event\player\PlayerQuitEvent;
+use pocketmine\event\player\PlayerJoinEvent;
 use pocketmine\Player;
 use pocketmine\tile\Sign;
 class EventListener implements Listener{

--- a/HungerGames/src/hungergames/EventListener.php
+++ b/HungerGames/src/hungergames/EventListener.php
@@ -99,7 +99,7 @@ class EventListener implements Listener{
         $p = $e->getPlayer();
         if($this->HGApi->getStorage()->isPlayerSet($p)){
             $game = $this->HGApi->getStorage()->getPlayerGame($p);
-            if($game !== null) $this->HGApi->getGlobalManager()->getGameManager($game)->removePlayerWithoutTeleport($p, true);
+            if($game !== null) $this->HGApi->getGlobalManager()->getGameManager($game)->removePlayer($p, true);
         }
         elseif($this->HGApi->getStorage()->isPlayerWaiting($p)){
             $game = $this->HGApi->getStorage()->getWaitingPlayerGame($p);
@@ -114,7 +114,7 @@ class EventListener implements Listener{
         if($this->HGApi->getStorage()->isPlayerSet($p)){
             $game = $this->HGApi->getStorage()->getPlayerGame($p);
             if($game !== null){
-                $this->HGApi->getGlobalManager()->getGameManager($game)->removePlayer($p);
+                $this->HGApi->getGlobalManager()->getGameManager($game)->removePlayerWithoutTeleport($p);
             }
             $count = $this->HGApi->getStorage()->getPlayersInGameCount($game);
             if($count > 1){
@@ -131,5 +131,12 @@ class EventListener implements Listener{
         if($this->HGApi->getStorage()->isPlayerWaiting($e->getPlayer())){
             $e->setCancelled();
         }
+    }
+    /**
+     * @param PlayerJoinEvent $e
+     */
+    public function onSpawn(PlayerJoinEvent $e){
+      $p = $e->getPlayer();
+      $p->getInventory()->clearAll();
     }
 }

--- a/HungerGames/src/hungergames/tasks/DeathMatchTask.php
+++ b/HungerGames/src/hungergames/tasks/DeathMatchTask.php
@@ -24,6 +24,7 @@ class DeathMatchTask extends PluginTask{
             $this->HGApi->getGlobalManager()->getGameManager($this->game)->setStatus("open");
             foreach($this->HGApi->getStorage()->getPlayersInGame($this->game) as $p){
                 $p->teleport($this->game->getLobbyPosition());
+                $p->getInventory()->clearAll();
                 foreach ($this->HGApi->getScriptManager()->getScripts() as $script) {
                     if (!$script->isEnabled()) continue;
                     $script->onPlayerWinGame($p, $this->game);

--- a/HungerGames/src/hungergames/tasks/GameRunningTask.php
+++ b/HungerGames/src/hungergames/tasks/GameRunningTask.php
@@ -45,6 +45,7 @@ class GameRunningTask extends PluginTask{
             $this->HGApi->getGlobalManager()->getGameManager($this->game)->setStatus("open");
             foreach($this->HGApi->getStorage()->getPlayersInGame($this->game) as $p){
                 $p->teleport($this->game->getLobbyPosition());
+                $p->getInventory()->clearAll();
                 foreach ($this->HGApi->getScriptManager()->getScripts() as $script) {
                     if (!$script->isEnabled()) continue;
                     $script->onPlayerWinGame($p, $this->game);


### PR DESCRIPTION
Now clears a players inventory when they login, win a match, or win a deathmatch. 

(Also realized my previous pull request changed playerQuitEvent() instead of playerDeathEvent(). My GitHub desktop doesn't seem to be working so I've been applying local changes to GitHub changes manually using web editor and changed the wrong event. Not sure how I missed this last week lol. Probably because I was testing removePlayerWithoutTeleport() on playerQuitEvent() at the time I was committing it to playerDeathEvent()) 